### PR TITLE
Make jsExpressionToPhp ignore '+' signs in strings

### DIFF
--- a/src/jsExpressionToPhp.coffee
+++ b/src/jsExpressionToPhp.coffee
@@ -7,12 +7,19 @@ jsExpressionToPhp = (jsExpr, opts = {}) ->
 	jsExpr = jsExpr.replace ///^\s*\(([a-zA-Z_][a-z_A-Z0-9]*(\.[a-zA-Z_][a-z_A-Z0-9]*)*)\)///g, '$1'
 	jsExpr = jsExpr.replace ///\+\s*\(([a-zA-Z_][a-z_A-Z0-9]*(\.[a-zA-Z_][a-z_A-Z0-9]*)*)\)///g, '+ $1'
 
+	# first, we prefix all tokens with a marker, so that we don't get confused later
+	token_re = /(([a-zA-Z_][a-z_A-Z0-9]*(\.[a-zA-Z_][a-z_A-Z0-9]*)*)|("[^"]*")|('[^']*')|(\d+))|(\s*\+\s*)/g
+	jsExpr = jsExpr.replace token_re, (s) -> '■' + s
+
 	replaced = yes
 	while replaced
 		replaced = no
-		jsExpr = jsExpr.replace ///(([a-zA-Z_][a-z_A-Z0-9]*(\.[a-zA-Z_][a-z_A-Z0-9]*)*)|("[^"]*")|('[^']*')|(\d+))(\s*\+\s*(([a-zA-Z_][a-z_A-Z0-9]*(\.[a-zA-Z_][a-z_A-Z0-9]*)*)|("[^"]*")|('[^']*')|(\d+)))+///g, (s) ->
+		jsExpr = jsExpr.replace ///(■([a-zA-Z_][a-z_A-Z0-9]*(\.[a-zA-Z_][a-z_A-Z0-9]*)*)|■("[^"]*")|■('[^']*')|■(\d+))(■\s*\+\s*(■([a-zA-Z_][a-z_A-Z0-9]*(\.[a-zA-Z_][a-z_A-Z0-9]*)*)|■("[^"]*")|■('[^']*')|■(\d+)))+///g, (s) ->
 			replaced = yes
-			"add(#{s.replace ///\s*\+\s*///g, ', '})"
+			"add(#{s.replace ///■\s*\+\s*///g, ', '})"
+
+	# removing any remaining token markers
+	jsExpr = jsExpr.replace /■/g, ''
 
 	phpCode = js2php jsExpr
 	phpExpression = phpCode.replace(///^<\?php\n///g, "").replace(///;\n$///g, "").replace(///;\n///g, "; ")

--- a/test/jsExpressionToPhp.test.coffee
+++ b/test/jsExpressionToPhp.test.coffee
@@ -67,3 +67,6 @@ describe 'jsExpressionToPhp', ->
 			arraysOnly: false
 		test 'a.b(c.d)', '$a->b($c->d)',
 			arraysOnly: false
+
+	it 'should not get confused by "+" sings inside strings', ->
+		test "'' + '+420'", "add('', '+420')"


### PR DESCRIPTION
This fixes issue #15 -- plus signs in js strings no longer confuse jsExpressionToPhp
