### PR TITLE
fix dynamic classes and attributes issue

### DIFF
--- a/src/JadePhpCompiler.coffee
+++ b/src/JadePhpCompiler.coffee
@@ -792,6 +792,12 @@ Compiler:: =
           (if classEscaping[i] then runtime.escape(cls) else cls)
         )))
       else
-        classes = "(jade_interp = " + utils.stringify(classEscaping) + "," + " jade.joinClasses([" + classes.join(",") + "].map(jade.joinClasses).map(function (cls, i) {" + "   return jade_interp[i] ? jade.escape(cls) : cls" + " }))" + ")"
+        classes = utils.stringify(runtime.joinClasses(classes.map(runtime.joinClasses).map((cls, i) =>
+          if isConstant(cls)
+            cls = toConstant(cls)
+            (if classEscaping[i] then runtime.escape(cls) else cls)
+          else
+            @jsExpressionToPhp cls
+        )))
       buf.push "\"class\": " + classes  if classes.length
     "{" + buf.join(",") + "}"


### PR DESCRIPTION
This is a fix for the mentioned bug in the discussion of #19.

I do not know if there needs to be some extra escaping for dynamic classes. Maybe we can discuss if this is a general solution or just works in our case when we have something like

``` jade
mixin mymixin()
  - foo = 'bar'
  div(class=foo)&attributes(attributes)
    block
```
